### PR TITLE
Proper setup of the BBGW Ti WLink Firmware

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -6,7 +6,7 @@ firmware_location=/lib/firmware/ti-connectivity
 mount_point=/mnt
 
 if [[ ! -e $mount_point$firmware_location ]]; then
-    mkdir $mount_point
+    mkdir $mount_point$firmware_location
     mount --bind $firmware_location $mount_point$firmware_location
 elif [[ ! -d $mount_point$firmware_location ]]; then
     echo "$mount_point already exists but is not a directory" 1>&2

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
 
 echo "Set up Bluetooth"
+
+firmware_location=/lib/firmware/ti-connectivity
+mount_point=/mnt/root
+
+if [[ ! -e $mount_point ]]; then
+    mkdir $mount_point
+    mount --bind $firmware_location $mount_point$firmware_location
+elif [[ ! -d $mount_point ]]; then
+    echo "$mount_point already exists but is not a directory" 1>&2
+fi
+
+cp $mount_point$firmware_location'/*' $firmware_location
 # Seem to have to run in twice, as the first run times out at the moment
 bb-wl18xx-bluetooth
 bb-wl18xx-bluetooth
@@ -11,4 +23,7 @@ while : ; do
   echo "Scan for Bluetooth devices"
   hcitool scan
   sleep 15
+  echo "Scan for Bluetooth LE devices"
+  hcitool scanle
+  sleep 15  
 done

--- a/start.sh
+++ b/start.sh
@@ -3,12 +3,12 @@
 echo "Set up Bluetooth"
 
 firmware_location=/lib/firmware/ti-connectivity
-mount_point=/mnt
+mount_point=/mnt/root
 
-if [[ ! -e $mount_point$firmware_location ]]; then
-    mkdir -p $mount_point$firmware_location
-    mount --bind $firmware_location $mount_point$firmware_location
-elif [[ ! -d $mount_point$firmware_location ]]; then
+if [[ ! -e $mount_point ]]; then
+    mkdir -p $mount_point
+    mount --bind / $mount_point
+elif [[ ! -d $mount_point ]]; then
     echo "$mount_point already exists but is not a directory" 1>&2
 fi
 

--- a/start.sh
+++ b/start.sh
@@ -12,7 +12,7 @@ elif [[ ! -d $mount_point ]]; then
     echo "$mount_point already exists but is not a directory" 1>&2
 fi
 
-cp $mount_point$firmware_location'/*' $firmware_location
+cp $mount_point$firmware_location'/*' $firmware_location'/'
 # Seem to have to run in twice, as the first run times out at the moment
 bb-wl18xx-bluetooth
 bb-wl18xx-bluetooth

--- a/start.sh
+++ b/start.sh
@@ -3,12 +3,12 @@
 echo "Set up Bluetooth"
 
 firmware_location=/lib/firmware/ti-connectivity
-mount_point=/mnt/root
+mount_point=/mnt
 
-if [[ ! -e $mount_point ]]; then
+if [[ ! -e $mount_point$firmware_location ]]; then
     mkdir $mount_point
     mount --bind $firmware_location $mount_point$firmware_location
-elif [[ ! -d $mount_point ]]; then
+elif [[ ! -d $mount_point$firmware_location ]]; then
     echo "$mount_point already exists but is not a directory" 1>&2
 fi
 

--- a/start.sh
+++ b/start.sh
@@ -5,17 +5,6 @@ echo "Set up Bluetooth"
 mkdir -p /mnt/root
 mount --bind / /mnt/root
 
-# firmware_location=/lib/firmware/ti-connectivity
-# mount_point=/mnt/root
-
-# if [[ ! -e $mount_point ]]; then
-#     mkdir -p $mount_point
-#     mount --bind / $mount_point
-# elif [[ ! -d $mount_point ]]; then
-#     echo "$mount_point already exists but is not a directory" 1>&2
-# fi
-
-# cp $mount_point$firmware_location'/*' $firmware_location'/'
 cp /mnt/root/lib/firmware/ti-connectivity/* /lib/firmware/ti-connectivity/
 
 

--- a/start.sh
+++ b/start.sh
@@ -6,7 +6,7 @@ firmware_location=/lib/firmware/ti-connectivity
 mount_point=/mnt
 
 if [[ ! -e $mount_point$firmware_location ]]; then
-    mkdir $mount_point$firmware_location
+    mkdir -p $mount_point$firmware_location
     mount --bind $firmware_location $mount_point$firmware_location
 elif [[ ! -d $mount_point$firmware_location ]]; then
     echo "$mount_point already exists but is not a directory" 1>&2

--- a/start.sh
+++ b/start.sh
@@ -2,17 +2,23 @@
 
 echo "Set up Bluetooth"
 
-firmware_location=/lib/firmware/ti-connectivity
-mount_point=/mnt/root
+mkdir -p /mnt/root
+mount --bind / /mnt/root
 
-if [[ ! -e $mount_point ]]; then
-    mkdir -p $mount_point
-    mount --bind / $mount_point
-elif [[ ! -d $mount_point ]]; then
-    echo "$mount_point already exists but is not a directory" 1>&2
-fi
+# firmware_location=/lib/firmware/ti-connectivity
+# mount_point=/mnt/root
 
-cp $mount_point$firmware_location'/*' $firmware_location'/'
+# if [[ ! -e $mount_point ]]; then
+#     mkdir -p $mount_point
+#     mount --bind / $mount_point
+# elif [[ ! -d $mount_point ]]; then
+#     echo "$mount_point already exists but is not a directory" 1>&2
+# fi
+
+# cp $mount_point$firmware_location'/*' $firmware_location'/'
+cp /mnt/root/lib/firmware/ti-connectivity/* /lib/firmware/ti-connectivity/
+
+
 # Seem to have to run in twice, as the first run times out at the moment
 bb-wl18xx-bluetooth
 bb-wl18xx-bluetooth


### PR DESCRIPTION
The script allows the installed files from bb-wl18xx-firmware to be unshadowed and copied back to the "mounted bind" directory /lib/firmware/ti-connectivity
